### PR TITLE
Fix name of Glyphfriend extension

### DIFF
--- a/src/pages/Frameworks/client-side.md
+++ b/src/pages/Frameworks/client-side.md
@@ -70,7 +70,7 @@ Get full IntelliSense for your Knockout view models in HTML data binding express
 ### Relevant extensions
 
 - [Web Essentials](https://visualstudiogallery.msdn.microsoft.com/ee6e6d8c-c837-41fb-886a-6b50ae2d06a2)
-- [Glyphfriends](https://visualstudiogallery.msdn.microsoft.com/5fd24afb-b3b2-4cec-9b03-1cfcec6123aa)
+- [Glyphfriend](https://visualstudiogallery.msdn.microsoft.com/5fd24afb-b3b2-4cec-9b03-1cfcec6123aa)
 - [Bootstrap Snippet Pack](https://visualstudiogallery.msdn.microsoft.com/e82e7862-f731-4183-a27a-3a44b261bfe5)
 - [Apache Cordova for Visual Studio 2013](http://www.microsoft.com/en-us/download/details.aspx?id=42675)
 - [React Snippet Pack](https://visualstudiogallery.msdn.microsoft.com/234d79e9-f0fd-41e1-a926-850da8e8c7d7)


### PR DESCRIPTION
This fixes a minor typo in the name of the Glyphfriend extension name.
