### PR TITLE
[BUG] unicode fail parse

### DIFF
--- a/src/index.cshtml
+++ b/src/index.cshtml
@@ -36,7 +36,7 @@
 			@Helpers.RenderBreadcrumb(PageSystem.GetCurrentPage(Request))
 		}
 
-		Response.Headers.Add("X-Title", Page.Title);
+	    Response.Headers.Add("X-Title", HttpUtility.UrlEncode(Page.Title));
 
 		if (next != null)
 		{

--- a/src/themes/standard/js/dataService.js
+++ b/src/themes/standard/js/dataService.js
@@ -16,7 +16,7 @@
 		xhr.setRequestHeader("X-Content-Only", "1");
 		xhr.onreadystatechange = function () {
 			if (xhr.readyState === 4 && xhr.status === 200) {
-				var page = { url: url, content: xhr.responseText, title: xhr.getResponseHeader("X-Title"), next: xhr.getResponseHeader("X-Next"), prev: xhr.getResponseHeader("X-Prev") };
+			    var page = { url: url, content: xhr.responseText, title: decodeURIComponent(xhr.getResponseHeader("X-Title")), next: xhr.getResponseHeader("X-Next"), prev: xhr.getResponseHeader("X-Prev") };
 				pageCache[url] = page;
 				callback(page);
 			}

--- a/src/themes/standard/output/site.js
+++ b/src/themes/standard/output/site.js
@@ -16,7 +16,7 @@ var dataService = (function () {
 		xhr.setRequestHeader("X-Content-Only", "1");
 		xhr.onreadystatechange = function () {
 			if (xhr.readyState === 4 && xhr.status === 200) {
-				var page = { url: url, content: xhr.responseText, title: xhr.getResponseHeader("X-Title"), next: xhr.getResponseHeader("X-Next"), prev: xhr.getResponseHeader("X-Prev") };
+			    var page = { url: url, content: xhr.responseText, title: decodeURIComponent(xhr.getResponseHeader("X-Title")), next: xhr.getResponseHeader("X-Next"), prev: xhr.getResponseHeader("X-Prev") };
 				pageCache[url] = page;
 				callback(page);
 			}


### PR DESCRIPTION
If the page-title contains unicode charactor eg:".NET 网站开发指南" ,the title from the headers["x-title"] will fail to parse .eg:" ç®è¿°".
